### PR TITLE
conf: extend list of terminfo paths (closes #8)

### DIFF
--- a/autoconf/aclocal.m4
+++ b/autoconf/aclocal.m4
@@ -507,9 +507,11 @@ else
    MISC_TERMINFO_DIRS=""
 fi
 JD_Terminfo_Dirs="$MISC_TERMINFO_DIRS \
+                  /etc/terminfo \
                   /usr/lib/terminfo \
                   /usr/share/terminfo \
                   /usr/share/lib/terminfo \
+                  /lib/terminfo \
 		  /usr/local/lib/terminfo"
 TERMCAP=-ltermcap
 

--- a/configure
+++ b/configure
@@ -8689,9 +8689,11 @@ else
    MISC_TERMINFO_DIRS=""
 fi
 JD_Terminfo_Dirs="$MISC_TERMINFO_DIRS \
+                  /etc/terminfo \
                   /usr/lib/terminfo \
                   /usr/share/terminfo \
                   /usr/share/lib/terminfo \
+                  /lib/terminfo \
 		  /usr/local/lib/terminfo"
 TERMCAP=-ltermcap
 


### PR DESCRIPTION
Should remove the need for Debian patch.